### PR TITLE
Inline identity (NodeJS tasks sample)

### DIFF
--- a/tasks/nodejs/index.ts
+++ b/tasks/nodejs/index.ts
@@ -1,5 +1,5 @@
 
-import { init, Ditto, IdentityOnlinePlayground, Document } from '@dittolive/ditto'
+import { init, Ditto, Document } from '@dittolive/ditto'
 import * as readline from 'readline/promises'
 import { stdin as input, stdout as output } from 'node:process';
 
@@ -11,8 +11,7 @@ let tasks: Document[] = []
 async function main () {
   await init()
 
-  const identity: IdentityOnlinePlayground = { type: 'onlinePlayground', appID: 'YOUR_APP_ID', token: 'YOUR_TOKEN' }
-  ditto = new Ditto(identity)
+  ditto = new Ditto({ type: 'onlinePlayground', appID: 'YOUR_APP_ID', token: 'YOUR_TOKEN' })
   ditto.startSync()
 
   subscription = ditto.store.collection("tasks").find("isDeleted == false").subscribe()


### PR DESCRIPTION
Inlines the identity as noted on Slack:

> And to complete the picture, Identity  was supposed to be just a "helper type" mainly to be used as "named parameters" for the Ditto constructor, that's why I went with "literal types".
>
> So, in general, you'd inline the identity (unless you really need a separate variable, in which case you ought to use `Identity`):
>
> ``` TypeScript
> const ditto = new Ditto({type: 'onlinePlayground', appID: '...', token: '...'})
> ```
>
> -- @konstantinbe
> https://dittolive.slack.com/archives/CRRAWK99A/p1673591813121239?thread_ts=1673573928.824029&cid=CRRAWK99A