### PR TITLE
Fix .gitignore to not ignore pbxproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,21 @@
-# Created by https://www.gitignore.io/api/xcode,swift
-# Edit at https://www.gitignore.io/?templates=xcode,swift
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+# https://github.com/github/gitignore/blob/main/Swift.gitignore
 
 .DS_Store
 
-## Xcode -----------------
-
-*.xcodeproj
-*.xcodeproj/*
-!*.xcodeproj/project.pbxproj
-!*.xcodeproj/xcshareddata/
-!*.xcworkspace/contents.xcworkspacedata
-# /*.gcno
+## User settings
 xcuserdata/
-**/xcshareddata/WorkspaceSettings.xcsettings 
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
 *.pbxuser
 !default.pbxuser
 *.mode1v3
@@ -21,66 +24,63 @@ xcuserdata/
 !default.mode2v3
 *.perspectivev3
 !default.perspectivev3
-xcuserdata/
-==========================
 
-## Build generated -------
-
-build/
-DerivedData/
-==========================
-
-## Other -----------------
-
-*.moved-aside
-*.xccheckout
-*.xcscmblueprint
-==========================
-
-## Obj-C/Swift specific --
-
+## Obj-C/Swift specific
 *.hmap
+
+## App packaging
 *.ipa
 *.dSYM.zip
 *.dSYM
-==========================
 
-## Playgrounds -----------
-
+## Playgrounds
 timeline.xctimeline
 playground.xcworkspace
-==========================
 
-## Swift Package Manager -
+# Swift Package Manager
+#
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 # Packages/
 # Package.pins
 # Package.resolved
-.build/
-==========================
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
 
-## CocoaPods -------------
+.build/
+
+# CocoaPods
+#
 # We recommend against adding the Pods directory to your .gitignore. However
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
 # Pods/
+#
 # Add this line if you want to avoid checking in source code from the Xcode workspace
 # *.xcworkspace
-==========================
 
-# Carthage ---------------
+# Carthage
+#
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
 
-Carthage/Build
-==========================
+Carthage/Build/
 
-## Code Injection -------
+# Accio dependency management
+Dependencies/
+.accio/
+
+
+# Code Injection
+#
 # After new code Injection tools there's a generated folder /iOSInjectionProject
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
-==========================
+
 
 ############################################################
 # Android                                                  #


### PR DESCRIPTION
Previous update to .gitignore included ignoring .pbxproj which includes build settings, file additions/removals in Navigator, etc., important to Xcode projects.